### PR TITLE
Fix #141: Make URL field required in proposal creation form

### DIFF
--- a/src/components/proposal/DescriptionProposal.jsx
+++ b/src/components/proposal/DescriptionProposal.jsx
@@ -14,7 +14,7 @@ import {Editor} from "react-draft-wysiwyg";
 import "react-draft-wysiwyg/dist/react-draft-wysiwyg.css";
 
 const schema = yup.object().shape({
-    proposalUrl: yup.string().url("Must be a valid url"),
+    proposalUrl: yup.string().url("Must be a valid url").required("URL is required"),
 });
 
 
@@ -185,6 +185,7 @@ function DescriptionProposal({onNext, onBack}) {
                     name="proposalUrl"
                     id="proposalUrl"
                     ref={register}
+                    required
                 />
                 <ErrorMessage
                     errors={errors}

--- a/src/components/proposal/ProposalForm.jsx
+++ b/src/components/proposal/ProposalForm.jsx
@@ -278,7 +278,7 @@ function ProposalForm() {
       title,
       name,
       description,
-      url: url || 'emptyField',
+      url,
       firstEpoch: payment.proposalStartEpoch,
       startEpoch: payment.proposalStartEpoch,
       endEpoch: payment.proposalEndEpoch,


### PR DESCRIPTION
- Add required validation to proposalUrl in yup schema
- Add required attribute to URL input field
- Remove 'emptyField' fallback for empty URLs
- Display 'URL is required' error message when field is empty